### PR TITLE
Fix CSS for mobile on referenda page

### DIFF
--- a/src/sass/referenda.scss
+++ b/src/sass/referenda.scss
@@ -11,7 +11,11 @@
   margin: 20px 10px;
   padding: 10px;
   white-space: pre-wrap;
-  width: 75%;
+  max-width: 75%;
+
+  @media (max-width:768px) {
+    max-width: 95%;
+  }
 }
 
 .referendum-title {


### PR DESCRIPTION
Makes CSS more consistent with the rest of the website, and more responsive/reasonable on mobile devices (i.e. by making the referendum cards fill up more space on the screen).