### PR TITLE
Remove many extraneous scrollbars on modal

### DIFF
--- a/src/sass/modal.scss
+++ b/src/sass/modal.scss
@@ -67,7 +67,7 @@
   background: #fff;
   border-radius: 5px;
   text-align: center;
-  overflow-y: scroll;
+  overflow: visible;
 }
 
 .modal-controls .modal-close {
@@ -111,7 +111,7 @@
   justify-content: flex-start;
   flex-direction: row;
   padding: 10px;
-  max-height: 80vh;
+  max-height: 72vh;
 }
 
 .candidateModalImageContainer {
@@ -161,7 +161,7 @@
 .candidateOverlayPlatform {
   flex: 5;
   max-width: 100%;
-  overflow: scroll;
+  overflow-y: scroll;
   font-family: 'IBM Plex Sans', sans-serif;
 }
 
@@ -200,7 +200,7 @@
   }
 
   .candidateOverlayPlatform {
-    overflow: visible;
+    overflow-y: visible;
     text-align: left;
   }
 }


### PR DESCRIPTION
I goofed and didn't test on Windows.

![31668675_1072765056207907_3827215528917729280_n](https://user-images.githubusercontent.com/10901793/39491177-4563b2d2-4d40-11e8-972a-a6e2971c1489.png)

This PR removes all those extra scrollbars and makes it slightly easier to notice that the endorsement text is scrollable.